### PR TITLE
Change Data Structure from list of ValidationRecords to ValidationObject

### DIFF
--- a/qiime2/core/testing/validator.py
+++ b/qiime2/core/testing/validator.py
@@ -7,20 +7,21 @@
 # ----------------------------------------------------------------------------
 
 import pandas as pd
+from qiime2 import Metadata
 from .type import Kennel, Dog, Cat
 from .plugin import dummy_plugin
 
 
-@dummy_plugin.register_validator(Kennel[Dog])
-def validator_test_null(view: str):
-    pass
+#@dummy_plugin.register_validator(Kennel[Dog])
+#def validator_test_null(view: str):
+#    pass
 
 
 @dummy_plugin.register_validator(Kennel[Dog | Cat])
-def test_subset_or(view: pd.DataFrame):
+def test_subset_or(view: dict):
     pass
 
 
 @dummy_plugin.register_validator(Kennel[Dog])
-def validator_test_null2(view: pd.Series):
+def validator_test_null2(view: Metadata):
     print('does know everything')

--- a/qiime2/core/validate.py
+++ b/qiime2/core/validate.py
@@ -6,25 +6,40 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-class SemanticValidation:
-    def __init__(self, validation_target, concrete_type, validators,
-                 validate_level):
-        self.data = validation_target
-        self.validators = validators
+class ValidationChain:
+    def __init__(self, concrete_type):
+        self._validators = []
         self.concrete_type = concrete_type
-        self.validate_level = validate_level
+        self._is_sorted = False
 
-    def _get_type_validators(self):
-        self.type_validators = self.validators[self.concrete_type]
+    def add_validator(self, validator):
+        self._validators += validator
+        self._is_sorted = False
+
+    def add_validation_oject(self, *others):
+        for other in others:
+            self._validators += other._validators
+        self._is_sorted = False
+
+
+    @property
+    def validators(self) -> list:
+        if not self._is_sorted:
+            self._validators = self._sort_validators()
+            self._is_sorted = True
+
+        return self._validators
 
     def _sort_validators(self):
         """does nothing right now"""
         self.sorted_validators = self.type_validators
         pass
 
-    def run_validators(self):
-        self._get_type_validators()
-        self._sort_validators()
+    def run_validators(self, target, validate_level: str = 'min'):
+        for validator in self.validators:
+            validator.validator(target)
+        #self._get_type_validators()
+        #self._sort_validators()
 
-        for validator in self.sorted_validators:
-            validator.validator(view=validator.view)
+        #for validator in self.sorted_validators:
+        #    validator.validator(view=validator.view)

--- a/qiime2/core/validate.py
+++ b/qiime2/core/validate.py
@@ -16,28 +16,26 @@ class ValidationChain:
         self._validators += validator
         self._is_sorted = False
 
-    def add_validation_oject(self, *others):
+    def add_validation_object(self, *others):
         for other in others:
             self._validators += other._validators
         self._is_sorted = False
 
 
     @property
-    def validators(self) -> list:
+    def validators(self):
         if not self._is_sorted:
             self._validators = self._sort_validators()
-            self._is_sorted = True
 
         return self._validators
 
     def _sort_validators(self):
         """does nothing right now"""
-        self.sorted_validators = self.type_validators
-        pass
+        self._is_sorted = True
 
     def run_validators(self, target, validate_level: str = 'min'):
         for validator in self.validators:
-            validator.validator(target)
+            validator.validator(target, view=validator.view)
         #self._get_type_validators()
         #self._sort_validators()
 

--- a/qiime2/plugin/plugin.py
+++ b/qiime2/plugin/plugin.py
@@ -11,6 +11,7 @@ import types
 
 import qiime2.sdk
 import qiime2.core.type.grammar as grammar
+from qiime2.core.validate import ValidationChain
 from qiime2.plugin.model import DirectoryFormat
 from qiime2.plugin.model.base import FormatBase
 from qiime2.core.type import is_semantic_type
@@ -146,15 +147,24 @@ class Plugin:
             if not validator.__annotations__['view']:
                 raise KeyError('No expected view type defined.' %
                                validator)
+
             for semantic_type in semantic_expression:
                 if semantic_type not in self.validators:
-                    self.validators[semantic_type] = []
-                self.validators[semantic_type].append(ValidatorRecord(
-                    validator=validator,
-                    view=validator.__annotations__['view'],
-                    plugin=self,
-                    context=semantic_expression))
-            return validator
+                    self.validators[semantic_type] = \
+                        ValidationChain(semantic_type)
+
+                self.validators[semantic_type].add_validator(
+                    ValidatorRecord(
+                        validator=validator,
+                        view=validator.__annotations__['view'],
+                        plugin=self,
+                        context=semantic_expression))
+                #self.validators[semantic_type].append(ValidatorRecord(
+                #    validator=validator,
+                #    view=validator.__annotations__['view'],
+                #    plugin=self,
+                #    context=semantic_expression))
+            #return validator
 
         return decorator
 

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -90,7 +90,7 @@ class PluginManager:
                 self.add_plugin(plugin, package, project_name,
                                 consistency_check=False)
 
-            self._consistency_check()
+            #self._consistency_check()
 
     def _consistency_check(self):
         for semantic_type, records in self.validators.items():
@@ -199,7 +199,7 @@ class PluginManager:
                 self.validators[semantic_type] = \
                     ValidationChain(semantic_type)
 
-            self.validators[semantic_type].add_validation_chain(chain)
+            self.validators[semantic_type].add_validation_object(chain)
 
     def get_semantic_types(self):
         types = {}

--- a/qiime2/sdk/plugin_manager.py
+++ b/qiime2/sdk/plugin_manager.py
@@ -14,6 +14,7 @@ import enum
 import qiime2.core.type
 from qiime2.core.format import FormatBase
 from qiime2.plugin.model import SingleFileDirectoryFormatBase
+from qiime2.core.validate import ValidationChain
 from qiime2.core.transform import ModelType
 from qiime2.sdk.util import parse_type
 from qiime2.core.type import is_semantic_type
@@ -100,7 +101,8 @@ class PluginManager:
                 mt_other = ModelType(record.view)
                 if not mt.has_transformation(mt_other):
                     raise ValueError(
-                        'Whoops! Something went wrong.'
+                        '%s No transformation available from %s to %s' %
+                        (record, mt._view_type, mt_other._view_type)
                     )
 
     def add_plugin(self, plugin, package=None, project_name=None,
@@ -192,12 +194,12 @@ class PluginManager:
             self.formats[name] = record
         self.type_formats.extend(plugin.type_formats)
 
-        for semantic_type, records in plugin.validators.items():
+        for semantic_type, chain in plugin.validators.items():
             if semantic_type not in self.validators:
-                self.validators[semantic_type] = []
+                self.validators[semantic_type] = \
+                    ValidationChain(semantic_type)
 
-            for record in records:
-                self.validators[semantic_type].append(record)
+            self.validators[semantic_type].add_validation_chain(chain)
 
     def get_semantic_types(self):
         types = {}

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -303,11 +303,7 @@ class Artifact(Result):
         transformation = from_type.make_transformation(to_type,
                                                        recorder=recorder)
         result = transformation(view, validate_level)
-        validator = validate.SemanticValidation(validation_target=result,
-                                                validators=pm.validators,
-                                                concrete_type=type,
-                                                validate_level=validate_level)
-        validator.run_validators()
+        #validator = pm.validators[view_type]
 
         artifact = cls.__new__(cls)
         artifact._archiver = archive.Archiver.from_data(

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -281,6 +281,7 @@ class Artifact(Result):
     @classmethod
     def _from_view(cls, type, view, view_type, provenance_capture,
                    validate_level='min'):
+        type_raw = type
         if isinstance(type, str):
             type = qiime2.sdk.parse_type(type)
 
@@ -303,7 +304,9 @@ class Artifact(Result):
         transformation = from_type.make_transformation(to_type,
                                                        recorder=recorder)
         result = transformation(view, validate_level)
-        #validator = pm.validators[view_type]
+        print('\n' + str(type.is_concrete()) + ' : ' + '\n')
+        if type in pm.validators:
+            validator = pm.validators[type]
 
         artifact = cls.__new__(cls)
         artifact._archiver = archive.Archiver.from_data(

--- a/qiime2/sdk/result.py
+++ b/qiime2/sdk/result.py
@@ -305,7 +305,7 @@ class Artifact(Result):
         result = transformation(view, validate_level)
         validator = validate.SemanticValidation(validation_target=result,
                                                 validators=pm.validators,
-                                                concrete_type=to_type,
+                                                concrete_type=type,
                                                 validate_level=validate_level)
         validator.run_validators()
 


### PR DESCRIPTION
Stores validation records inside dictionary of `semantic_type: ValidationObject` pairs. This allows storing of sorting and also consistency checks. The class that constructs the ValidationObjects provides(or will provide) methods for adding validators, combining ValidationObjects that share the same key, sorting the validators, checking the ability to transform to appropriate views, running the validators, etc.